### PR TITLE
Fix for PID files that have more than one line

### DIFF
--- a/templates/initscript.erb
+++ b/templates/initscript.erb
@@ -38,14 +38,15 @@ case $1 in
   ;;
   'stop')
   <%- if defined?(@cmd) -%>
-  if [ -z "$(cat $PIDFILE)" ];
+  PID="$( head -1 $PIDFILE 2>/dev/null )"
+  if [ -z "$PID" ];
   then
     echo "stopped"
     exit 1
   else
-    kill $(cat $PIDFILE)
+    kill "$PID"
     sleep 1
-    kill -9 $(cat $PIDFILE)
+    kill -9 "$PID"
     sleep 1
     rm $PIDFILE
     exit 0
@@ -99,12 +100,13 @@ case $1 in
     exit 1
   fi
   <%- else -%>
-    if [ -z "$(cat $PIDFILE 2>/dev/null)" ];
+    PID="$( head -1 $PIDFILE 2>/dev/null )"
+    if [ -z "$PID" ];
     then
       echo "stopped"
       exit 1
     else
-      if [ $(ps -p $(cat $PIDFILE) | wc -l 2>/dev/null) -eq 2 ];
+      if [ $(ps -p "$PID" | wc -l 2>/dev/null) -eq 2 ];
       then
         echo "running"
         exit 0


### PR DESCRIPTION
Some services (like PostgreSQL) create PID files with more lines of output in them. This fix only uses the first line of a PID file to get the numeric PID value so that any additional lines are ignored.

Additionally, captured the PID in a variable and reused it instead of retrieving it from the PIDFILE every time.